### PR TITLE
Fix broken clang 8 build about "bit_not" use

### DIFF
--- a/depends/common/retro8/0002-FixClang8.patch
+++ b/depends/common/retro8/0002-FixClang8.patch
@@ -1,0 +1,29 @@
+From 9bf5670d31c7ab88a9c8fbead00911b17e4dc443 Mon Sep 17 00:00:00 2001
+From: Alwin Esch <alwin.esch@web.de>
+Date: Mon, 15 Nov 2021 22:48:30 +0100
+Subject: [PATCH] Fix broken clang 8 build about:
+
+```
+error: no member named 'bit_not' in namespace 'std'
+```
+
+---
+ src/vm/lua_bridge.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/vm/lua_bridge.cpp b/src/vm/lua_bridge.cpp
+index 0174cd5..5b14b16 100755
+--- a/src/vm/lua_bridge.cpp
++++ b/src/vm/lua_bridge.cpp
+@@ -672,7 +672,7 @@ namespace bitwise
+ 
+     data_t a = lua_tonumber(L, 1);
+ 
+-    lua_pushnumber(L, std::bit_not<data_t>()(a));
++    lua_pushnumber(L, ~a);
+ 
+     return 1;
+   }
+-- 
+2.30.2
+


### PR DESCRIPTION
Fix broken clang 8 build about:

```
error: no member named 'bit_not' in namespace 'std'
```

For https://github.com/xbmc/xbmc/issues/20329